### PR TITLE
Some suggested changes

### DIFF
--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -45,7 +45,7 @@ module Pool = Pool
 (** Cancelling fibers. *)
 module Cancel = Eio__core.Cancel
 
-(** A high-level domain task pool *)
+(** A pool of domains for executing jobs. *)
 module Executor_pool = Executor_pool
 
 (** Commonly used standard features. This module is intended to be [open]ed. *)

--- a/lib_eio/executor_pool.ml
+++ b/lib_eio/executor_pool.ml
@@ -1,76 +1,76 @@
 type job = Pack : (unit -> 'a) * ('a, exn) Result.t Promise.u -> job
 
-(* Worker: 1 domain/thread
-   m jobs per worker, n domains per executor_pool *)
-
 type t = {
-  stream: job Stream.t;
-  cancelled: bool Atomic.t;
+  queue : job Stream.t;
+  cancelled : bool Atomic.t;
 }
 
 (* This function is the core of executor_pool.ml.
-   Each worker recursively calls [loop ()] until the [terminating]
-   promise is resolved. Workers pull one job at a time from the Stream. *)
-let start_worker ~limit stream =
+   Each worker runs in its own domain,
+   taking jobs from [queue] whenever it has spare capacity. *)
+let run_worker ~limit queue =
   Switch.run @@ fun sw ->
   let capacity = Semaphore.make limit in
-  let run_job job w =
-    Fiber.fork ~sw (fun () ->
-        Promise.resolve w
-          (try Ok (job ()) with
-           | exn -> Error exn);
-        Semaphore.release capacity )
-  in
   (* The main worker loop. *)
   let rec loop () =
     Semaphore.acquire capacity;
-    let actions = Stream.take stream in
-    match actions with
-    | Pack (job, w) ->
-      (* Give a chance to other domains to start waiting on the Stream before the current thread blocks on [Stream.take] again. *)
-      Fiber.yield ();
-      run_job job w;
-      (loop [@tailcall]) ()
+    let Pack (fn, w) = Stream.take queue in
+    Fiber.fork ~sw (fun () ->
+        Promise.resolve w (try Ok (fn ()) with ex -> Error ex);
+        Semaphore.release capacity
+      );
+    (* Give a chance to other domains to start waiting on [queue]
+       before the current thread blocks on [Stream.take] again. *)
+    Fiber.yield ();
+    (loop [@tailcall]) ()
   in
   loop ()
 
-(* Start a new domain. The worker will need a switch, then we start the worker. *)
-let start_domain ~sw ~domain_mgr ~limit stream =
-  let go () =
-    Domain_manager.run domain_mgr (fun () -> start_worker ~limit stream )
-  in
-  (* Executor_pools run as daemons to not hold the user's switch from completing.
-     It's up to the user to hold the switch open (and thus, the executor_pool)
-     by blocking on the jobs issued to the executor_pool. *)
-  Fiber.fork_daemon ~sw (fun () ->
-      let _ = go () in
-      `Stop_daemon )
+let rec reject_all queue =
+  match Stream.take_nonblocking queue with
+  | None -> ()
+  | Some (Pack (_fn, w)) ->
+    Promise.resolve_error w (Failure "Executor_pool: Switch finished");
+    reject_all queue
 
 let create ~sw ~domain_count ~domain_concurrency domain_mgr =
-  let stream = Stream.create 0 in
-  let instance = { stream; cancelled = Atomic.make false } in
-  Switch.on_release sw (fun () -> Atomic.set instance.cancelled true);
+  let queue = Stream.create 0 in
+  let t = { queue; cancelled = Atomic.make false } in
+  Switch.on_release sw (fun () -> Atomic.set t.cancelled true; reject_all queue);
   for _ = 1 to domain_count do
-    start_domain ~sw ~domain_mgr ~limit:domain_concurrency stream
+    (* Workers run as daemons to not hold the user's switch from completing.
+       It's up to the user to hold the switch open (and thus, the executor pool)
+       by blocking on the jobs issued to the pool. *)
+    Fiber.fork_daemon ~sw (fun () ->
+        Domain_manager.run domain_mgr (fun () ->
+            run_worker ~limit:domain_concurrency queue
+          )
+      )
   done;
-  instance
+  t
 
-let enqueue { stream; cancelled } f =
-  if Atomic.get cancelled then raise (Failure "Executor_pool: Switch cancelled");
+let enqueue { queue; cancelled } f =
   let p, w = Promise.create () in
-  Stream.add stream (Pack (f, w));
+  Fiber.both
+    (fun () -> Stream.add queue (Pack (f, w)))
+    (fun () ->
+       (* By this point, the previous fiber suspended,
+          so our job was either accepted or is waiting in the queue. *)
+       if Atomic.get cancelled then (
+         (* Possibly all the workers have already finished by now.
+            To avoid our job stitting in the queue forever, reject any remaining
+            jobs (including our own if noone else gets there first). *)
+         reject_all queue;
+       )
+    );
   p
 
-let submit_fork ~sw instance f =
-  Fiber.fork_promise ~sw (fun () ->
-    enqueue instance f
-    |> Promise.await_exn )
+let submit t f =
+  enqueue t f |> Promise.await
 
-let submit instance f =
-  enqueue instance f
-  |> Promise.await
+let submit_exn t f =
+  enqueue t f |> Promise.await_exn
 
-let submit_exn instance f =
-  match submit instance f with
-  | Ok x -> x
-  | Error exn -> raise exn
+let submit_fork ~sw t f =
+  (* [enqueue] blocks until the job is accepted, so we have to fork here. *)
+  Fiber.fork_promise ~sw (fun () -> submit_exn t f)

--- a/lib_eio/executor_pool.mli
+++ b/lib_eio/executor_pool.mli
@@ -1,22 +1,45 @@
+(** An executor pool distributes jobs among a pool of domains.
+
+    Usually you will only want one pool for an entire application,
+    so the pool is typically created when the application starts:
+
+    {[
+      let () =
+        Eio_main.run @@ fun env ->
+        Switch.run @@ fun sw ->
+        let pool =
+          Eio.Executor_pool.create ~sw env#domain_mgr
+            ~domain_count:2
+            ~domain_concurrency:1
+        in
+        main ~pool
+    ]}
+*)
+
 type t
+(** An executor pool. *)
 
-(** Creates a new Executor_pool with [domain_count].
-
-    [domain_concurrency] is the maximum number of jobs that each domain can run at a time.
-
-    The Executor_pool will not block the [~sw] Switch from completing. *)
 val create :
   sw:Switch.t ->
   domain_count:int ->
   domain_concurrency:int ->
   _ Domain_manager.t ->
   t
+(** [create ~sw ~domain_count ~domain_concurrency dm] creates a new executor pool.
 
-(** Run a job on this Executor_pool. It is placed at the end of the queue. *)
+    The executor pool will not block switch [sw] from completing;
+    when the switch finishes, all worker domains and running jobs are cancelled.
+
+    @param domain_count The number of worker domains to create.
+    @param domain_concurrency The maximum number of jobs that each domain can run at a time. *)
+
 val submit : t -> (unit -> 'a) -> ('a, exn) result
+(** [submit t fn] runs [fn ()] using this executor pool.
 
-(** Same as [submit] but raises if the job failed. *)
+    The job is added to the back of the queue. *)
+
 val submit_exn : t -> (unit -> 'a) -> 'a
+(** Same as {!submit} but raises if the job fails. *)
 
-(** Same as [submit] but returns immediately, without blocking. *)
-val submit_fork : sw:Switch.t -> t -> (unit -> 'a) -> ('a, exn) result Promise.t
+val submit_fork : sw:Switch.t -> t -> (unit -> 'a) -> 'a Promise.or_exn
+(** Same as {!submit} but returns immediately, without blocking. *)

--- a/tests/executor_pool.md
+++ b/tests/executor_pool.md
@@ -1,7 +1,6 @@
 # Setting up the environment
 
 ```ocaml
-# #require "eio_main";;
 # #require "eio.mock";;
 ```
 
@@ -42,7 +41,7 @@ let run fn =
     let actual = t1 -. t0 in
     if Float.(actual = expected)
     then (traceln "Duration (valid): %.0f" expected; res)
-    else failwith (Format.sprintf "Duration was not %.0f: %.0f" expected actual)
+    else Fmt.failwith "Duration was not %.0f: %.0f" expected actual
   in
   fn mgr sleep duration
 ```
@@ -187,7 +186,7 @@ Exception: Failure "3".
 
 # Blocking for capacity
 
-`Executor_pool.submit` will block waiting for room in the queue:
+`Executor_pool.submit_exn` will block waiting for room in the queue:
 
 ```ocaml
 # run @@ fun mgr sleep duration ->
@@ -276,5 +275,5 @@ Exception: Failure "3".
     Executor_pool.submit_exn ep (fun () -> sleep 50.; incr count);
     traceln "Count: %d" !count
 +[0] Duration (valid): 0
-Exception: Failure "Executor_pool: Switch cancelled".
+Exception: Failure "Executor_pool: Switch finished".
 ```


### PR DESCRIPTION
- Ensure any queued jobs are rejected at shutdown.
- Avoid race where the pool is finished after the client checks but before it submits.
- Explain how to use it in the docs.

Minor:
- Rename `stream` to `queue` to indicate what it's for.
- `yield` after starting the job, not before.
- Inline some trivial functions.
- General bike-shedding changes.